### PR TITLE
Filter extra motion events

### DIFF
--- a/MTShell.h
+++ b/MTShell.h
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#import "Terminal.h"
 
 @class MTParserState;
 
@@ -22,4 +23,6 @@
 - (void) MouseTerm_setParserState: (MTParserState*) parserState;
 - (MTParserState*) MouseTerm_getParserState;
 
+- (void) MouseTerm_cachePosition: (Position*) pos;
+- (BOOL) MouseTerm_positionIsChanged: (Position*) pos;
 @end

--- a/MTShell.m
+++ b/MTShell.m
@@ -3,6 +3,7 @@
 #import "MouseTerm.h"
 #import "MTParserState.h"
 #import "MTShell.h"
+#import "Terminal.h"
 
 @implementation NSObject (MTShell)
 
@@ -32,6 +33,7 @@
     NSValue *ptr = [self MouseTerm_initVars];
     [[MouseTerm_ivars objectForKey: ptr]
         setObject: [NSNumber numberWithInt:mouseMode] forKey: @"mouseMode"];
+    [self MouseTerm_cachePosition: nil];
 }
 
 - (int) MouseTerm_getMouseMode
@@ -47,6 +49,7 @@
     [[MouseTerm_ivars objectForKey: ptr]
         setObject: [NSNumber numberWithInt:mouseProtocol]
            forKey: @"mouseProtocol"];
+    [self MouseTerm_cachePosition: nil];
 }
 
 - (int) MouseTerm_getMouseProtocol
@@ -106,6 +109,29 @@
         return;
 
     [self MouseTerm_writeData: data];
+}
+
+- (void) MouseTerm_cachePosition: (Position*) pos
+{
+    NSValue *ptr = [self MouseTerm_initVars];
+    if (pos) {
+        [[MouseTerm_ivars objectForKey: ptr]
+            setObject: [NSValue valueWithBytes: pos objCType: @encode(Position)]
+               forKey: @"positionCache"];
+    } else {
+        [[MouseTerm_ivars objectForKey: ptr] removeObjectForKey: @"positionCache"];
+    }
+}
+
+- (BOOL) MouseTerm_positionIsChanged: (Position*) pos;
+{
+    Position cache;
+    NSValue *ptr = [self MouseTerm_initVars];
+    NSValue *value = [[MouseTerm_ivars objectForKey: ptr] objectForKey: @"positionCache"];
+    if (!value)
+        return YES;
+    [value getValue: &cache];
+    return cache.x != pos->x || cache.y != pos->y;
 }
 
 // Deletes instance variables

--- a/MTView.h
+++ b/MTView.h
@@ -3,10 +3,12 @@
 #import "Terminal.h"
 
 @interface NSView (MTView)
-- (NSData*) MouseTerm_codeForEvent: (NSEvent*) event
-                            button: (MouseButton) button
-                            motion: (BOOL) motion
-                           release: (BOOL) release;
+- (NSData*) MouseTerm_codeForX: (unsigned int) x
+                             Y: (unsigned int) y
+                      modifier: (char) modflag
+                        button: (MouseButton) button
+                        motion: (BOOL) motion
+                       release: (BOOL) release;
 + (void) MouseTerm_setEnabled: (BOOL) value;
 + (BOOL) MouseTerm_getEnabled;
 - (NSScroller*) MouseTerm_scroller;


### PR DESCRIPTION
Current MouseTerm emits extra motion events. This fix improves the experience of mouse dragging, especially for the case of using applications over SSH.

reference:
http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#Mouse%20Tracking

> Motion events are reported only if the mouse pointer has moved to a different character cell.

see also:
https://github.com/gnachman/iTerm2/pull/109